### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Watchers](https://img.shields.io/github/watchers/ArtLabss/tennis-tracking.svg)
 ![Last Commit](https://img.shields.io/github/last-commit/ArtLabss/tennis-tracking.svg) 
 
-<h3>Objectvies</h3>
+<h3>Objectives</h3>
 <ul>
   <li>Track the ball </li>
   <li>Detect court lines </li>


### PR DESCRIPTION
There was a typo in the word "Objectives"